### PR TITLE
Adding the PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Description
+*Please include a summary of the change and which issue number is fixed (e.g. Fixes #1). Please also include relevant motivation and context.*
+
+## How has this been tested?
+*Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.*
+
+## Screenshots
+*Provide screenshots of what has been implemented. Leave blank if not applicable*
+
+## Checklist
+*(Leave blank if not applicable)*
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I have checked my code and corrected any misspellings


### PR DESCRIPTION
## Description

I have added an `pull_request_template.md` file within the `.github` directory in the root, which has the structure of what we want our pull requests to look like. This format has been agreed on by all team members.

Closes #2

## How has this been tested?

N/A

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings