### PR TITLE
Fix path for BuddyMatcherApplicationTests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -41,4 +41,4 @@
 /src/main/java/com/team701/buddymatcher/repositories/users/ @uoa-ypec413 @jafarmaash
 
 # Shared
-/src/main/java/com/team701/buddymatcher/BuddyMatcherApplicationTests.java @ejstuart @ff-dev-45 @ThomasHolsterUOA @jafarmaash
+/src/test/java/com/team701/buddymatcher/BuddyMatcherApplicationTests.java @ejstuart @ff-dev-45 @ThomasHolsterUOA @jafarmaash


### PR DESCRIPTION
## Description
Fixing code owners file: I wrote the wrong path for `BuddyMatcherApplicationTests.java`
Currently is `/src/main/java/com/team701/buddymatcher/BuddyMatcherApplicationTests.java`
Should be `/src/test/java/com/team701/buddymatcher/BuddyMatcherApplicationTests.java`

## How has this been tested?
N/A

## Screenshots
N/A

## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
