### PR TITLE
Creation of blank AddBuddy endpoint + pairing controller/service 

### DIFF
--- a/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
@@ -1,0 +1,36 @@
+package com.team701.buddymatcher.controllers.pairing;
+
+import com.team701.buddymatcher.dtos.pairing.AddBuddyDTO;
+import com.team701.buddymatcher.services.pairing.PairingService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@Api
+@RequestMapping("/api/pairing/")
+public class PairingController {
+
+    private final PairingService pairingService;
+
+    @Autowired
+    public PairingController(PairingService pairingService) {
+        this.pairingService = pairingService;
+    }
+
+    @ApiOperation("Post method for adding a new buddy record between two users")
+    @PostMapping(path = "/addBuddy/",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity addBuddy(@RequestBody AddBuddyDTO buddyRequest) {
+        pairingService.addBuddy(buddyRequest.getUserId(), buddyRequest.getBuddyId());
+        //Temporary return message since the addBuddy method is not implemented and this is a blank endpoint
+        String result = String.format("\"Success: %s, %s \"",buddyRequest.getUserId(),buddyRequest.getBuddyId());
+        return new ResponseEntity(result, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/team701/buddymatcher/dtos/pairing/AddBuddyDTO.java
+++ b/src/main/java/com/team701/buddymatcher/dtos/pairing/AddBuddyDTO.java
@@ -1,0 +1,26 @@
+package com.team701.buddymatcher.dtos.pairing;
+
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+/**
+ * Data Transfer Object representing a request to add a buddy to a user
+ */
+public class AddBuddyDTO {
+    private String userId;
+    private String buddyId;
+
+    public String getUserId() {return userId;}
+
+    public String getBuddyId() {
+        return buddyId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public void setBuddyId(String buddyId) {
+        this.buddyId = buddyId;
+    }
+
+}

--- a/src/main/java/com/team701/buddymatcher/services/pairing/PairingService.java
+++ b/src/main/java/com/team701/buddymatcher/services/pairing/PairingService.java
@@ -1,0 +1,9 @@
+package com.team701.buddymatcher.services.pairing;
+
+/**
+ *  Handles the incoming requests related to pairing of buddies endpoints
+ */
+public interface PairingService {
+    void addBuddy(String userId, String buddyId);
+
+}

--- a/src/main/java/com/team701/buddymatcher/services/pairing/impl/PairingServiceImpl.java
+++ b/src/main/java/com/team701/buddymatcher/services/pairing/impl/PairingServiceImpl.java
@@ -1,0 +1,18 @@
+package com.team701.buddymatcher.services.pairing.impl;
+
+import com.team701.buddymatcher.services.pairing.PairingService;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementation for the PairingService which is a service providing the implementations of the methods
+ * for the pairing endpoints
+ */
+@Service
+public class PairingServiceImpl implements PairingService {
+
+    @Override
+    public void addBuddy(String userId, String buddyId) {
+        //Currently just a blank implementation for testing endpoint call
+        System.out.println(String.format("Buddy add request: %s, %s",userId,buddyId));
+    }
+}

--- a/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
@@ -1,0 +1,48 @@
+package com.team701.buddymatcher.controllers.pairing;
+
+import com.team701.buddymatcher.dtos.pairing.AddBuddyDTO;
+import com.team701.buddymatcher.services.pairing.PairingService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+public class PairingControllerIntegrationTest {
+
+    @Mock
+    private PairingService pairingService;
+
+    @InjectMocks
+    private PairingController pairingController;
+
+    @Test
+    void addValidNewBuddy() {
+        String userId = UUID.randomUUID().toString();
+        String buddyId = UUID.randomUUID().toString();
+
+        AddBuddyDTO buddyRequest = createMockedAddBuddyDTO(userId, buddyId);
+
+        ResponseEntity response = pairingController.addBuddy(buddyRequest);
+
+        //Temp response
+        String success = String.format("\"Success: %s, %s \"", userId, buddyId);
+
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(response.getStatusCode(), HttpStatus.OK);
+        Assertions.assertEquals(response.getBody(), success);
+    }
+
+    AddBuddyDTO createMockedAddBuddyDTO(String userId, String buddyId) {
+        var dto = new AddBuddyDTO();
+        dto.setUserId(userId);
+        dto.setBuddyId(buddyId);
+        return dto;
+    }
+}


### PR DESCRIPTION
## Description

This changes adds in the `PairingController`, `PairingService`, and the `addBuddy` endpoint, as well as a `AddBuddyDTO` which is the current method for sending in the userId & buddyId for the new buddies that are being created

The actual `addBuddy` method is currently not implemented, as this was just setting up the endpoint and structure

Also the integration test was setup and a unit test was added that currently works for the blank implementation, it will need to be updated when the endpoint is implemented properly

Fixes #28 

## How has this been tested?
I ran the server and tested the endpoint with swagger to see if it returned as expected, which it did

I also created a unit test in the `PairingControllerIntegrationTest` file to test that the endpoint works as expected for the blank implementation of the endpoint

## Screenshots

## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
