### PR TITLE
Create  removeBuddy blank endpoint

### DIFF
--- a/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
@@ -33,4 +33,13 @@ public class PairingController {
         return new ResponseEntity(result, HttpStatus.OK);
     }
 
-}
+    @ApiOperation("Delete method for removing a buddy record between two users")
+    @PostMapping(path = "/removeBuddy/",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity removeBuddy(@RequestBody DeleteBuddyDTO buddyRequest) {
+        pairingService.removeBuddy(buddyRequest.getUserId(), buddyRequest.getBuddyId());
+        //Temporary return message since the removeBuddy method is not implemented and this is a blank endpoint
+        String result = String.format("\"Removed: %s, %s \"",buddyRequest.getUserId(),buddyRequest.getBuddyId());
+        return new ResponseEntity(result, HttpStatus.OK);
+    }

--- a/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
@@ -35,13 +35,13 @@ public class PairingController {
     }
 
     @ApiOperation("Delete method for removing a buddy record between two users")
-    @PostMapping(path = "/removeBuddy/",
+    @DeleteMapping(path = "/removeBuddy/",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity removeBuddy(@RequestBody RemoveBuddyDTO buddyRequest) {
         pairingService.removeBuddy(buddyRequest.getUserId(), buddyRequest.getBuddyId());
         //Temporary return message since the removeBuddy method is not implemented and this is a blank endpoint
-        String result = String.format("\"Successfully Removed: %s, %s \"",buddyRequest.getUserId(),buddyRequest.getBuddyId());
+        String result = String.format("\"Removed: %s, %s \"",buddyRequest.getUserId(),buddyRequest.getBuddyId());
         return new ResponseEntity(result, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
@@ -1,6 +1,7 @@
 package com.team701.buddymatcher.controllers.pairing;
 
 import com.team701.buddymatcher.dtos.pairing.AddBuddyDTO;
+import com.team701.buddymatcher.dtos.pairing.RemoveBuddyDTO;
 import com.team701.buddymatcher.services.pairing.PairingService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -37,9 +38,10 @@ public class PairingController {
     @PostMapping(path = "/removeBuddy/",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity removeBuddy(@RequestBody DeleteBuddyDTO buddyRequest) {
+    public ResponseEntity removeBuddy(@RequestBody RemoveBuddyDTO buddyRequest) {
         pairingService.removeBuddy(buddyRequest.getUserId(), buddyRequest.getBuddyId());
         //Temporary return message since the removeBuddy method is not implemented and this is a blank endpoint
         String result = String.format("\"Successfully Removed: %s, %s \"",buddyRequest.getUserId(),buddyRequest.getBuddyId());
         return new ResponseEntity(result, HttpStatus.OK);
     }
+}

--- a/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
@@ -40,6 +40,6 @@ public class PairingController {
     public ResponseEntity removeBuddy(@RequestBody DeleteBuddyDTO buddyRequest) {
         pairingService.removeBuddy(buddyRequest.getUserId(), buddyRequest.getBuddyId());
         //Temporary return message since the removeBuddy method is not implemented and this is a blank endpoint
-        String result = String.format("\"Removed: %s, %s \"",buddyRequest.getUserId(),buddyRequest.getBuddyId());
+        String result = String.format("\"Successfully Removed: %s, %s \"",buddyRequest.getUserId(),buddyRequest.getBuddyId());
         return new ResponseEntity(result, HttpStatus.OK);
     }

--- a/src/main/java/com/team701/buddymatcher/dtos/pairing/RemoveBuddyDTO.java
+++ b/src/main/java/com/team701/buddymatcher/dtos/pairing/RemoveBuddyDTO.java
@@ -1,7 +1,5 @@
 package com.team701.buddymatcher.dtos.pairing;
 
-import org.springframework.web.bind.annotation.ModelAttribute;
-
 /**
  * Data Transfer Object representing a request to remove a buddy from a user
  */

--- a/src/main/java/com/team701/buddymatcher/dtos/pairing/RemoveBuddyDTO.java
+++ b/src/main/java/com/team701/buddymatcher/dtos/pairing/RemoveBuddyDTO.java
@@ -1,0 +1,28 @@
+package com.team701.buddymatcher.dtos.pairing;
+
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+/**
+ * Data Transfer Object representing a request to remove a buddy from a user
+ */
+public class RemoveBuddyDTO {
+    private String userId;
+    private String buddyId;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getBuddyId() {
+        return buddyId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public void setBuddyId(String buddyId) {
+        this.buddyId = buddyId;
+    }
+
+}

--- a/src/main/java/com/team701/buddymatcher/services/pairing/PairingService.java
+++ b/src/main/java/com/team701/buddymatcher/services/pairing/PairingService.java
@@ -5,5 +5,6 @@ package com.team701.buddymatcher.services.pairing;
  */
 public interface PairingService {
     void addBuddy(String userId, String buddyId);
+    
     void removeBuddy(String userId, String buddyId);
 }

--- a/src/main/java/com/team701/buddymatcher/services/pairing/PairingService.java
+++ b/src/main/java/com/team701/buddymatcher/services/pairing/PairingService.java
@@ -5,5 +5,5 @@ package com.team701.buddymatcher.services.pairing;
  */
 public interface PairingService {
     void addBuddy(String userId, String buddyId);
-
+    void deleteBuddy(String userId, String buddyId);
 }

--- a/src/main/java/com/team701/buddymatcher/services/pairing/PairingService.java
+++ b/src/main/java/com/team701/buddymatcher/services/pairing/PairingService.java
@@ -5,5 +5,5 @@ package com.team701.buddymatcher.services.pairing;
  */
 public interface PairingService {
     void addBuddy(String userId, String buddyId);
-    void deleteBuddy(String userId, String buddyId);
+    void removeBuddy(String userId, String buddyId);
 }

--- a/src/main/java/com/team701/buddymatcher/services/pairing/impl/PairingServiceImpl.java
+++ b/src/main/java/com/team701/buddymatcher/services/pairing/impl/PairingServiceImpl.java
@@ -15,4 +15,10 @@ public class PairingServiceImpl implements PairingService {
         //Currently just a blank implementation for testing endpoint call
         System.out.println(String.format("Buddy add request: %s, %s",userId,buddyId));
     }
+    
+    @Override
+    public void removeBuddy(String userId, String buddyId) {
+        //Currently just a blank implementation for testing endpoint call
+        System.out.println(String.format("Buddy remove request: %s, %s",userId,buddyId));
+    }
 }

--- a/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.team701.buddymatcher.controllers.pairing;
 
 import com.team701.buddymatcher.dtos.pairing.AddBuddyDTO;
+import com.team701.buddymatcher.dtos.pairing.RemoveBuddyDTO;
 import com.team701.buddymatcher.services.pairing.PairingService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -63,7 +64,7 @@ public class PairingControllerIntegrationTest {
         Assertions.assertEquals(response.getBody(), success);
     }
 
-    RemoveBuddyDTO createMockedAddBuddyDTO(String userId, String buddyId) {
+    RemoveBuddyDTO createMockedRemoveBuddyDTO(String userId, String buddyId) {
         var dto = new RemoveBuddyDTO();
         dto.setUserId(userId);
         dto.setBuddyId(buddyId);

--- a/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
@@ -45,4 +45,28 @@ public class PairingControllerIntegrationTest {
         dto.setBuddyId(buddyId);
         return dto;
     }
+
+    @Test 
+    void removeValidBuddy() {
+        String userId = UUID.randomUUID().toString();
+        String buddyId = UUID.randomUUID().toString();
+
+        RemoveBuddyDTO buddyRequest = createMockedRemoveBuddyDTO(userId, buddyId);
+
+        ResponseEntity response = pairingController.removeBuddy(buddyRequest);
+
+        //Temp response
+        String success = String.format("\"Successfully Removed: %s, %s \"", userId, buddyId);
+
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(response.getStatusCode(), HttpStatus.OK);
+        Assertions.assertEquals(response.getBody(), success);
+    }
+
+    RemoveBuddyDTO createMockedAddBuddyDTO(String userId, String buddyId) {
+        var dto = new RemoveBuddyDTO();
+        dto.setUserId(userId);
+        dto.setBuddyId(buddyId);
+        return dto;
+    }
 }


### PR DESCRIPTION
## Description
Key changes include adding a blank endpoint for `removeBuddy` and adding a `RemoveBuddyDTO` which is the method for sending the userId & buddyId to remove the buddy pair.  

`removeBuddy` currently has no implementation, this is just setting up a blank endpoint.

Fixes #29 

## How has this been tested?
I ran the server and tested the endpoint on Swagger which returns the expected output. 

I also added a unit test in `PairingControllerIntegrationTest` to test and receive an expected output from the blank endpoint.  

## Screenshots

## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
