### PR TITLE
Change ical4j dependency version from 4.0.0-alpha8 -> 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.mnode.ical4j</groupId>
             <artifactId>ical4j</artifactId>
-            <version>4.0.0-alpha8</version>
+            <version>3.2.1</version>
         </dependency>
 
 


### PR DESCRIPTION
## Description
Bumps down ical4j dependency version from 4.0.0-alpha8 -> 3.2.1 to fix bug which prevents compilation due to an error with the `iterator() ` method

Fixes #69 

## How has this been tested?
Ran `mvn test` and all existing tests pass
Ran the application and compiles successfully

## Screenshots

## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
