### PR TITLE
Fixing user retrieval from a refactor change

### DIFF
--- a/src/main/java/com/team701/buddymatcher/services/timetable/impl/TimetableServiceImpl.java
+++ b/src/main/java/com/team701/buddymatcher/services/timetable/impl/TimetableServiceImpl.java
@@ -86,7 +86,7 @@ public class TimetableServiceImpl implements TimetableService {
 
     @Transactional
     public void populateCourses(Long studentId, List<String> courseNames) {
-        User user = userService.retrieve(studentId);
+        User user = userService.retrieveById(studentId);
         for (String courseName : courseNames) {
             Course course = courseRepository.findByName(courseName);
 

--- a/src/test/java/com/team701/buddymatcher/services/timetable/TimetableServiceImplUnitTests.java
+++ b/src/test/java/com/team701/buddymatcher/services/timetable/TimetableServiceImplUnitTests.java
@@ -39,7 +39,7 @@ public class TimetableServiceImplUnitTests {
 
         List<String> courseNames = Arrays.asList("se701", "se750", "enggen303");
 
-        Mockito.when(userService.retrieve(userId)).thenReturn(user);
+        Mockito.when(userService.retrieveById(userId)).thenReturn(user);
         for (String courseName : courseNames) {
             Mockito.when(courseRepository.findByName(courseName)).thenReturn(null);
         }
@@ -62,7 +62,7 @@ public class TimetableServiceImplUnitTests {
         Mockito.when(courseRepository.findByName("se701")).thenReturn(course);
         Mockito.when(courseRepository.findByName("enggen303")).thenReturn(null);
 
-        Mockito.when(userService.retrieve(userId)).thenReturn(user);
+        Mockito.when(userService.retrieveById(userId)).thenReturn(user);
 
         timetableService.populateCourses(userId, courseNames);
 
@@ -83,7 +83,7 @@ public class TimetableServiceImplUnitTests {
         List<String> courseNames = Arrays.asList("se701");
         Mockito.when(courseRepository.findByName("se701")).thenReturn(course);
 
-        Mockito.when(userService.retrieve(userId)).thenReturn(user);
+        Mockito.when(userService.retrieveById(userId)).thenReturn(user);
 
         timetableService.populateCourses(userId, courseNames);
 


### PR DESCRIPTION
## Description
Fixed all the locations that were using the old method `retrieve` instead of the new `retrieveById` checked that those tests that were failing and preventing the build have since been fixed

Fixes #85 

## How has this been tested?
Ran maven test and only tests that were already failing due to authorisation pr are still failing, but these tests now pass

## Screenshots

## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
