### PR TITLE
Add a validate token endpoint

### DIFF
--- a/src/main/java/com/team701/buddymatcher/controllers/users/UserController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/users/UserController.java
@@ -136,7 +136,7 @@ public class UserController {
         }
     }
 
-    @Operation(summary = "Post method insert a user as a buddy")
+    @Operation(summary = "Delete method to delete a user's buddy")
     @DeleteMapping(path = "/buddy/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> deleteUserBuddy(@PathVariable("id") Long userId, @RequestParam Long buddyId) { // TODO remove userId with Auth middleware
         try {

--- a/src/main/java/com/team701/buddymatcher/controllers/users/ValidateController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/users/ValidateController.java
@@ -1,0 +1,36 @@
+package com.team701.buddymatcher.controllers.users;
+
+import com.team701.buddymatcher.config.JwtTokenUtil;
+import io.jsonwebtoken.SignatureException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@Tag(name = "Validation")
+@RequestMapping("/api/validate")
+public class ValidateController {
+
+    private static final JwtTokenUtil jwtTokenUtil = new JwtTokenUtil();
+
+    @Operation(summary = "Get method to check that a JWT token is valid")
+    @GetMapping(path = "")
+    @ResponseStatus(value = HttpStatus.NO_CONTENT)
+    public void validateToken(HttpServletRequest request) {
+        try {
+            String token = request.getHeader("token");
+
+            jwtTokenUtil.validateToken(token);
+
+        } catch (SignatureException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+}

--- a/src/test/java/com/team701/buddymatcher/controllers/users/ValidateControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/users/ValidateControllerIntegrationTest.java
@@ -1,0 +1,57 @@
+package com.team701.buddymatcher.controllers.users;
+
+import com.team701.buddymatcher.config.JwtTokenUtil;
+import com.team701.buddymatcher.domain.users.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Random;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "socketio.host=localhost",
+        "socketio.port=8085"
+})
+@AutoConfigureMockMvc
+public class ValidateControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ValidateController validateController;
+
+    private static final JwtTokenUtil jwtTokenUtil = new JwtTokenUtil();
+
+    @Test
+    void validateValidToken() throws Exception {
+        String token = createValidToken();
+
+        mvc.perform(get("/api/validate")
+                .header("token", token))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void validateInvalidToken() throws Exception {
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+        mvc.perform(get("/api/validate")
+                .header("token", token))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private String createValidToken() {
+        User user = new User()
+                .setId(new Random().nextLong())
+                .setName("Pink Elephant")
+                .setEmail("pink.elephant@gmail.com");
+
+        return jwtTokenUtil.generateToken(user);
+    }
+}

--- a/src/test/java/com/team701/buddymatcher/controllers/users/ValidateControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/users/ValidateControllerIntegrationTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
         "socketio.host=localhost",
-        "socketio.port=8085"
+        "socketio.port=8087"
 })
 @AutoConfigureMockMvc
 public class ValidateControllerIntegrationTest {


### PR DESCRIPTION
## Description
Adds an endpoint to validate a JWT token. This is so that pages in the frontend that don't make requests can find out whether the user is authenticated.

GET /api/validate
Header: token
Response:
204 No Content when token valid
401 Unauthorized when token invalid

Closes #84 

## How has this been tested?
Wrote and ran an integration test testing both a valid and invalid token and their corresponding responses
Tested both invalid and valid tokens via postman
Endpoint shows up in Swagger:
![image](https://user-images.githubusercontent.com/68877945/158903824-d1391b80-0c2d-449b-843b-f1f5b5bbb327.png)

## Screenshots

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
