### PR TITLE
Implement Auth Interceptor and refactor endpoints to use Auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.3.13</version>
+        </dependency>
+
+
+
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
             <version>0.9.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,14 +94,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>5.3.13</version>
-        </dependency>
-
-
-
-        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
             <version>0.9.1</version>

--- a/src/main/java/com/team701/buddymatcher/SwaggerConfig.java
+++ b/src/main/java/com/team701/buddymatcher/SwaggerConfig.java
@@ -1,5 +1,7 @@
 package com.team701.buddymatcher;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
@@ -10,6 +12,13 @@ import org.springframework.context.annotation.Configuration;
 
 
 @Configuration
+@SecurityScheme(
+        name = "JWT",
+        description = "JWT authentication with bearer token",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "Bearer [token]"
+)
 public class SwaggerConfig {
 
     @Bean

--- a/src/main/java/com/team701/buddymatcher/config/JwtTokenUtil.java
+++ b/src/main/java/com/team701/buddymatcher/config/JwtTokenUtil.java
@@ -19,7 +19,7 @@ public class JwtTokenUtil implements Serializable {
 
     private static final long serialVersionUID = -2550185165626007488L;
 
-    public static final long JWT_TOKEN_VALIDITY = 5 * 60 * 60;
+    public static final long JWT_TOKEN_VALIDITY = 5 * 60 * 60 * 1000;
 
     @Value("$shhitsasecret")
     private String secret = "shhitsasecret";
@@ -61,7 +61,7 @@ public class JwtTokenUtil implements Serializable {
         return Jwts.builder().setClaims(claims)
                 .setSubject(subject)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(2022, 12, 10))
+                .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY))
                 .signWith(SignatureAlgorithm.HS512, secret).compact();
     }
 

--- a/src/main/java/com/team701/buddymatcher/config/JwtTokenUtil.java
+++ b/src/main/java/com/team701/buddymatcher/config/JwtTokenUtil.java
@@ -29,6 +29,10 @@ public class JwtTokenUtil implements Serializable {
         return getClaimFromToken(token, Claims::getSubject);
     }
 
+    public String getIdFromToken(String token){
+        final Claims claims = getAllClaimsFromToken(token);
+        return claims.get("UserId").toString();    }
+
     public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) {
         final Claims claims = getAllClaimsFromToken(token);
         return claimsResolver.apply(claims);

--- a/src/main/java/com/team701/buddymatcher/config/JwtTokenUtil.java
+++ b/src/main/java/com/team701/buddymatcher/config/JwtTokenUtil.java
@@ -57,6 +57,7 @@ public class JwtTokenUtil implements Serializable {
         return Jwts.builder().setClaims(claims)
                 .setSubject(subject)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(2022, 12, 10))
                 .signWith(SignatureAlgorithm.HS512, secret).compact();
     }
 

--- a/src/main/java/com/team701/buddymatcher/config/MvcConfig.java
+++ b/src/main/java/com/team701/buddymatcher/config/MvcConfig.java
@@ -1,0 +1,24 @@
+package com.team701.buddymatcher.config;
+
+import com.team701.buddymatcher.interceptor.UserInterceptor;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@EnableWebMvc
+@Configuration
+@ComponentScan("com.team701.buddymatcher.controllers")
+public class MvcConfig implements WebMvcConfigurer {
+
+    public MvcConfig() {
+        super();
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        // Pre-handle all requests except those which go to the login endpoint
+        registry.addInterceptor(new UserInterceptor()).excludePathPatterns("/login");
+    }
+}

--- a/src/main/java/com/team701/buddymatcher/config/MvcConfig.java
+++ b/src/main/java/com/team701/buddymatcher/config/MvcConfig.java
@@ -1,6 +1,7 @@
 package com.team701.buddymatcher.config;
 
 import com.team701.buddymatcher.interceptor.UserInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -12,13 +13,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @ComponentScan("com.team701.buddymatcher.controllers")
 public class MvcConfig implements WebMvcConfigurer {
 
-    public MvcConfig() {
-        super();
-    }
-
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         // Pre-handle all requests except those which go to the login endpoint
-        registry.addInterceptor(new UserInterceptor()).excludePathPatterns("/login");
+        registry.addInterceptor(new UserInterceptor())
+                .addPathPatterns("/**")
+                .excludePathPatterns(
+                        "/fake/login",
+                        "/login",
+                        "/register"
+                );
     }
 }

--- a/src/main/java/com/team701/buddymatcher/controllers/communication/CommunicationController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/communication/CommunicationController.java
@@ -4,21 +4,26 @@ import com.team701.buddymatcher.domain.communication.Message;
 import com.team701.buddymatcher.dtos.communication.MessageDTO;
 import com.team701.buddymatcher.services.communication.CommunicationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @RestController
 @Tag(name = "Communication")
 @RequestMapping("/api/communication")
+@SessionAttributes("UserId")
+@SecurityRequirement(name = "JWT")
 public class CommunicationController {
 
     private final CommunicationService communicationService;
@@ -33,12 +38,16 @@ public class CommunicationController {
 
     @Operation(summary = "Get method to get all messages sent to a given user")
     @GetMapping(path = "/messages/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<MessageDTO>> getMessages(@PathVariable("id") Long userId, @Param("buddyId") Long buddyId) {
-        List<Message> messages = communicationService.getMessages(userId, buddyId);
-        List<MessageDTO> messageDTOs = messages.stream()
-                .map(message -> modelMapper.map(message, MessageDTO.class))
-                .collect(Collectors.toList());
+    public ResponseEntity<List<MessageDTO>> getMessages(@Parameter(hidden = true) @SessionAttribute("UserId") Long userId, @PathVariable("id") Long buddyId) {
+        try {
+            List<Message> messages = communicationService.getMessages(userId, buddyId);
+            List<MessageDTO> messageDTOs = messages.stream()
+                    .map(message -> modelMapper.map(message, MessageDTO.class))
+                    .collect(Collectors.toList());
 
-        return new ResponseEntity<>(messageDTOs, HttpStatus.OK);
+            return new ResponseEntity<>(messageDTOs, HttpStatus.OK);
+        } catch(NoSuchElementException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+        }
     }
 }

--- a/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
@@ -1,12 +1,12 @@
 package com.team701.buddymatcher.controllers.pairing;
 
 import com.team701.buddymatcher.domain.users.User;
-import com.team701.buddymatcher.dtos.pairing.AddBuddyDTO;
 import com.team701.buddymatcher.dtos.pairing.MatchBuddyDTO;
-import com.team701.buddymatcher.dtos.pairing.RemoveBuddyDTO;
 import com.team701.buddymatcher.dtos.users.UserDTO;
 import com.team701.buddymatcher.services.pairing.PairingService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,17 +14,20 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @RestController
 @Tag(name="Pairing")
 @RequestMapping("/api/pairing/")
+@SessionAttributes("UserId")
+@SecurityRequirement(name = "JWT")
 public class PairingController {
 
     private final PairingService pairingService;
-
     private final ModelMapper modelMapper;
 
     @Autowired
@@ -33,46 +36,33 @@ public class PairingController {
         this.modelMapper = modelMapper;
     }
 
-    @Operation(summary = "Post method for adding a new buddy record between two users")
-    @PostMapping(path = "/addBuddy/",
-            consumes = MediaType.APPLICATION_JSON_VALUE,
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity addBuddy(@RequestBody AddBuddyDTO buddyRequest) {
-        pairingService.addBuddy(buddyRequest.getUserId(), buddyRequest.getBuddyId());
-        return new ResponseEntity(HttpStatus.OK);
-    }
-
-    @Operation(summary = "Delete method for removing a buddy record between two users")
-    @DeleteMapping(path = "/removeBuddy/",
-            consumes = MediaType.APPLICATION_JSON_VALUE,
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity removeBuddy(@RequestBody RemoveBuddyDTO buddyRequest) {
-        pairingService.removeBuddy(buddyRequest.getUserId(), buddyRequest.getBuddyId());
-        return new ResponseEntity(HttpStatus.OK);
-    }
-
     @Operation(summary = "Get method for finding possible matches for a user given a list of courses to match through")
-    @GetMapping(path = "/matchBuddy/{userId}",
+    @GetMapping(path = "/matchBuddy",
                 consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity matchBuddy(@PathVariable("userId") Long userId, @RequestBody MatchBuddyDTO buddyMatchRequest) {
-        List<User> results = pairingService.matchBuddy(userId,buddyMatchRequest.getCourseIds());
-        List<Long> currentBuddies = pairingService.getBuddyIds(userId);
+    public ResponseEntity matchBuddy(@Parameter(hidden = true) @SessionAttribute("UserId") Long userId, @RequestBody MatchBuddyDTO buddyMatchRequest) {
+        try {
+            List<User> results = pairingService.matchBuddy(userId,
+                    buddyMatchRequest.getCourseIds());
+            List<Long> currentBuddies = pairingService.getBuddyIds(userId);
 
-        /**Filter the list of possible buddies,
-         * 1. If the user is open to pairing,
-         * 2. If they are the current user,
-         * 3. If they are already a buddy of the user,
-         * Finally map it to a UserDto*/
+            /**Filter the list of possible buddies,
+             * 1. If the user is open to pairing,
+             * 2. If they are the current user,
+             * 3. If they are already a buddy of the user,
+             * Finally map it to a UserDto*/
 
-        List<UserDTO> matches = results.stream()
-                .filter(User::getPairingEnabled)
-                .filter(user -> !user.getId().equals(userId))
-                .filter(user -> !currentBuddies.contains(user.getId()))
-                .map(user -> modelMapper.map(user, UserDTO.class))
-                .collect(Collectors.toList());
-        if (matches.size() == 0) {
-            return new ResponseEntity(HttpStatus.NO_CONTENT);
+            List<UserDTO> matches = results.stream()
+                    .filter(User::getPairingEnabled)
+                    .filter(user -> !user.getId().equals(userId))
+                    .filter(user -> !currentBuddies.contains(user.getId()))
+                    .map(user -> modelMapper.map(user, UserDTO.class))
+                    .collect(Collectors.toList());
+            if (matches.size() == 0) {
+                return new ResponseEntity(HttpStatus.NO_CONTENT);
+            }
+            return new ResponseEntity(matches, HttpStatus.OK);
+        } catch (NoSuchElementException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
         }
-        return new ResponseEntity(matches,HttpStatus.OK);
     }
 }

--- a/src/main/java/com/team701/buddymatcher/controllers/timetable/TimetableController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/timetable/TimetableController.java
@@ -1,12 +1,11 @@
 package com.team701.buddymatcher.controllers.timetable;
 
 import com.team701.buddymatcher.domain.timetable.Course;
-import com.team701.buddymatcher.domain.timetable.Timetable;
-import com.team701.buddymatcher.domain.users.User;
 import com.team701.buddymatcher.dtos.timetable.CourseDTO;
-import com.team701.buddymatcher.dtos.users.UserDTO;
 import com.team701.buddymatcher.services.timetable.TimetableService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +22,8 @@ import java.util.stream.Collectors;
 @RestController
 @Tag(name = "Timetable")
 @RequestMapping("/api/timetable")
+@SessionAttributes("UserId")
+@SecurityRequirement(name = "JWT")
 public class TimetableController {
     private final TimetableService timetableService;
 
@@ -34,16 +35,19 @@ public class TimetableController {
         this.modelMapper = modelMapper;
     }
 
-    @Operation(summary ="Get a user's Timetable by their id")
-    @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Timetable> findTimetable(@RequestParam(name = "u") String userId) {
-        Timetable t = timetableService.retrieve("");
-        return new ResponseEntity<>(t, HttpStatus.OK);
+    @Operation(summary ="Get method to get all user's courses")
+    @GetMapping(path = "/users/courses", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<CourseDTO>> getSelfCourses (@Parameter(hidden = true) @SessionAttribute("UserId") Long userId) {
+        return getCourseListById(userId);
     }
 
     @Operation(summary ="Get method to get all user's courses")
     @GetMapping(path = "/users/courses/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<CourseDTO>> getCourses (@PathVariable("id") Long userId) {
+        return getCourseListById(userId);
+    }
+
+    private ResponseEntity<List<CourseDTO>> getCourseListById(Long userId) {
         try {
             List<Course> courses = timetableService.getCourses(userId);
             List<CourseDTO> courseDTOs = courses.stream()
@@ -52,12 +56,13 @@ public class TimetableController {
 
             return new ResponseEntity<>(courseDTOs, HttpStatus.OK);
         } catch (NoSuchElementException e) {
+
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
         }
     }
 
     @Operation(summary ="Get method to get a course using courseId")
-    @GetMapping(path = "/courses/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(path = "/course/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CourseDTO> getCourse (@PathVariable("id") Long courseId) {
         try {
             Course course = timetableService.getCourse(courseId);
@@ -68,6 +73,5 @@ public class TimetableController {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Course not found");
         }
     }
-
 }
 

--- a/src/main/java/com/team701/buddymatcher/controllers/users/UserController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/users/UserController.java
@@ -10,6 +10,8 @@ import com.team701.buddymatcher.domain.users.User;
 import com.team701.buddymatcher.dtos.users.UserDTO;
 import com.team701.buddymatcher.services.users.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import javax.persistence.NonUniqueResultException;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -30,6 +33,8 @@ import java.util.stream.Collectors;
 @RestController
 @Tag(name = "Users")
 @RequestMapping("/api/users")
+@SessionAttributes("UserId")
+@SecurityRequirement(name = "JWT")
 public class UserController {
 
     private final UserService userService;
@@ -42,11 +47,21 @@ public class UserController {
         this.modelMapper = modelMapper;
     }
 
+    @Operation(summary = "Get method to retrieve self")
+    @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<UserDTO> retrieveSelf(@Parameter(hidden = true) @SessionAttribute("UserId") Long userId) {
+        return getUserById(userId);
+    }
+
     @Operation(summary = "Get method to retrieve a user by id")
     @GetMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserDTO> retrieveUserById(@PathVariable("id") Long id) {
+        return getUserById(id);
+    }
+
+    private ResponseEntity<UserDTO> getUserById(Long userId) {
         try {
-            User user = userService.retrieveById(id);
+            User user = userService.retrieveById(userId);
             UserDTO userDTO = modelMapper.map(user, UserDTO.class);
 
             return new ResponseEntity<>(userDTO, HttpStatus.OK);
@@ -55,11 +70,11 @@ public class UserController {
         }
     }
 
-    @Operation(summary = "Put method to update a user's pairingEnabled field")
-    @PutMapping(path = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<UserDTO> updatePairingEnabled(@PathVariable("id") Long id, @RequestParam Boolean pairingEnabled) {
+    @Operation(summary = "Put method to update a own pairingEnabled field")
+    @PutMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<UserDTO> updatePairingEnabled(@Parameter(hidden = true) @SessionAttribute("UserId") Long userId, @RequestParam Boolean pairingEnabled) {
         try {
-            User user = userService.updatePairingEnabled(id, pairingEnabled);
+            User user = userService.updatePairingEnabled(userId, pairingEnabled);
             UserDTO userDTO = modelMapper.map(user, UserDTO.class);
 
             return new ResponseEntity<>(userDTO, HttpStatus.OK);
@@ -103,16 +118,14 @@ public class UserController {
             JwtTokenUtil util = new JwtTokenUtil();
             String token = util.generateToken(user);
             return new ResponseEntity<>(token, HttpStatus.OK);
-
-
         } else {
-            return new ResponseEntity<>("Invalid token", HttpStatus.UNAUTHORIZED);
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
         }
     }
 
     @Operation(summary = "Get method to retrieve a list of buddy from a user")
-    @GetMapping(path = "/buddy/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<UserDTO>> getUserBuddy(@PathVariable("id") Long userId) { // TODO remove userId with Auth middleware
+    @GetMapping(path = "/buddy", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<UserDTO>> getUserBuddy(@Parameter(hidden = true) @SessionAttribute("UserId") Long userId) {
         try {
             List<User> users = userService.retrieveBuddiesByUserId(userId);
             List<UserDTO> userDTOs = users.stream()
@@ -127,7 +140,7 @@ public class UserController {
 
     @Operation(summary = "Post method insert a user as a buddy")
     @PostMapping(path = "/buddy/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> postUserBuddy(@PathVariable("id") Long userId, @RequestParam Long buddyId) { // TODO remove userId with Auth middleware
+    public ResponseEntity<Void> postUserBuddy(@Parameter(hidden = true) @SessionAttribute("UserId") Long userId, @PathVariable("id") Long buddyId) {
         try {
             userService.addBuddy(userId, buddyId);
             return new ResponseEntity<>(HttpStatus.OK);
@@ -138,7 +151,7 @@ public class UserController {
 
     @Operation(summary = "Delete method to delete a user's buddy")
     @DeleteMapping(path = "/buddy/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> deleteUserBuddy(@PathVariable("id") Long userId, @RequestParam Long buddyId) { // TODO remove userId with Auth middleware
+    public ResponseEntity<Void> deleteUserBuddy(@Parameter(hidden = true) @SessionAttribute("UserId") Long userId, @PathVariable("id") Long buddyId) {
         try {
             userService.deleteBuddy(userId, buddyId);
             return new ResponseEntity<>(HttpStatus.OK);
@@ -147,4 +160,39 @@ public class UserController {
         }
     }
 
+    /**
+     * TODO: remove fake login (for frontend testing)
+     */
+    @Operation(summary = "Get method for a fake Login for testing")
+    @GetMapping(path = "/fake/login/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> getFakeLogin(@PathVariable("id") Long userId) {
+        try {
+            User user = userService.retrieveById(userId);
+            JwtTokenUtil util = new JwtTokenUtil();
+            String token = util.generateToken(user);
+            return new ResponseEntity<>(token, HttpStatus.OK);
+        } catch (NoSuchElementException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Bad Request");
+        }
+    }
+
+    /**
+     * TODO: remove fake register (for frontend testing)
+     */
+    @Operation(summary = "Get method for a fake Register for testing")
+    @GetMapping(path = "/fake/register", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<UserDTO> getFakeRegister(@RequestParam("name") String name, @RequestParam("email") String email) {
+        try {
+            userService.addUser(name, email);
+            User user = userService.retrieveByEmail(email);
+            UserDTO userDTO = new UserDTO()
+                    .setId(user.getId())
+                    .setEmail(user.getEmail())
+                    .setName(user.getName())
+                    .setPairingEnabled(user.getPairingEnabled());
+            return new ResponseEntity<>(userDTO, HttpStatus.OK);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Bad Request");
+        }
+    }
 }

--- a/src/main/java/com/team701/buddymatcher/domain/users/User.java
+++ b/src/main/java/com/team701/buddymatcher/domain/users/User.java
@@ -17,10 +17,10 @@ public class User {
     @Column(name = "USER_NAME", nullable = false)
     private String name;
 
-    @Column(name = "USER_EMAIL", nullable = false)
+    @Column(name = "USER_EMAIL", nullable = false, unique = true)
     private String email;
 
-    @Column(name = "USER_PAIRING_ENABLED")
+    @Column(name = "USER_PAIRING_ENABLED", columnDefinition = "boolean default false")
     private Boolean pairingEnabled;
 
     @ManyToMany(mappedBy = "users")

--- a/src/main/java/com/team701/buddymatcher/interceptor/UserInterceptor.java
+++ b/src/main/java/com/team701/buddymatcher/interceptor/UserInterceptor.java
@@ -30,6 +30,6 @@ public class UserInterceptor implements HandlerInterceptor {
     // Add UserId to request session so that the controller doesn't have to decode the JWT to get it
     // To get the ID from the session, call request.getSession().getAttribute("UserId");
     private void addToUserDetails(HttpSession session, String UserId) {
-        session.setAttribute("UserId", UserId);
+        session.setAttribute("UserId", Long.parseLong(UserId));
     }
 }

--- a/src/main/java/com/team701/buddymatcher/interceptor/UserInterceptor.java
+++ b/src/main/java/com/team701/buddymatcher/interceptor/UserInterceptor.java
@@ -1,0 +1,34 @@
+package com.team701.buddymatcher.interceptor;
+
+import com.team701.buddymatcher.config.JwtTokenUtil;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+public class UserInterceptor implements HandlerInterceptor {
+
+    /**
+     * Executed before actual handler is executed
+     **/
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object object) throws Exception {
+        String token = request.getHeader("token");
+        if (request.getRequestURI().contains("login")){
+            return true;
+        }
+        JwtTokenUtil validator = new JwtTokenUtil();
+        if(validator.validateToken(token)){
+            String username = validator.getUsernameFromToken(token);
+            System.out.println("get Username from token: " + username);
+            addToUserDetails(request.getSession(), username);
+            return true;
+        }
+        return false;
+    }
+
+    private void addToUserDetails(HttpSession session, String username) {
+        session.setAttribute("Username", username);
+    }
+}

--- a/src/main/java/com/team701/buddymatcher/interceptor/UserInterceptor.java
+++ b/src/main/java/com/team701/buddymatcher/interceptor/UserInterceptor.java
@@ -14,17 +14,34 @@ public class UserInterceptor implements HandlerInterceptor {
      **/
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object object) throws Exception {
-        String token = request.getHeader("token");
-        if (request.getRequestURI().contains("login")){
-            return true;
-        }
-        JwtTokenUtil validator = new JwtTokenUtil();
-        if(validator.validateToken(token)){
-            String UserId = validator.getIdFromToken(token);
-            addToUserDetails(request.getSession(), UserId);
-            return true;
-        }
+        try {
+            String url = request.getRequestURI();
+            String token = request.getHeader("Authorization");
+            if (url.contains("swagger")
+                    || url.contains("api-docs")
+                    || url.contains("webjars")
+                    || url.contains("login")
+                    || url.contains("register")
+            ) {
+                return true;
+            }
+
+            if (token == null || token == "") {
+                return false;
+            }
+
+            token = token.replace("Bearer ","");
+
+            JwtTokenUtil validator = new JwtTokenUtil();
+            if(validator.validateToken(token)){
+                String UserId = validator.getIdFromToken(token);
+                addToUserDetails(request.getSession(), UserId);
+                return true;
+            }
         return false;
+        }catch(IllegalArgumentException e) {
+            return false;
+        }
     }
 
     // Add UserId to request session so that the controller doesn't have to decode the JWT to get it

--- a/src/main/java/com/team701/buddymatcher/interceptor/UserInterceptor.java
+++ b/src/main/java/com/team701/buddymatcher/interceptor/UserInterceptor.java
@@ -20,15 +20,16 @@ public class UserInterceptor implements HandlerInterceptor {
         }
         JwtTokenUtil validator = new JwtTokenUtil();
         if(validator.validateToken(token)){
-            String username = validator.getUsernameFromToken(token);
-            System.out.println("get Username from token: " + username);
-            addToUserDetails(request.getSession(), username);
+            String UserId = validator.getIdFromToken(token);
+            addToUserDetails(request.getSession(), UserId);
             return true;
         }
         return false;
     }
 
-    private void addToUserDetails(HttpSession session, String username) {
-        session.setAttribute("Username", username);
+    // Add UserId to request session so that the controller doesn't have to decode the JWT to get it
+    // To get the ID from the session, call request.getSession().getAttribute("UserId");
+    private void addToUserDetails(HttpSession session, String UserId) {
+        session.setAttribute("UserId", UserId);
     }
 }

--- a/src/main/java/com/team701/buddymatcher/services/users/impl/UserServiceImpl.java
+++ b/src/main/java/com/team701/buddymatcher/services/users/impl/UserServiceImpl.java
@@ -34,7 +34,9 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public User retrieveByEmail(String email) {return userRepository.findUserByEmail(email);    }
+    public User retrieveByEmail(String email) {
+        return userRepository.findUserByEmail(email);
+    }
 
     @Override
     public void addUser(String name, String email) {

--- a/src/test/java/com/team701/buddymatcher/controllers/communication/CommunicationControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/communication/CommunicationControllerIntegrationTest.java
@@ -1,14 +1,19 @@
 package com.team701.buddymatcher.controllers.communication;
 
-import com.team701.buddymatcher.controllers.users.UserController;
+import com.team701.buddymatcher.interceptor.UserInterceptor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -26,7 +31,18 @@ public class CommunicationControllerIntegrationTest {
     private MockMvc mvc;
 
     @Autowired
-    UserController userController;
+    CommunicationController communicationController;
+
+    @MockBean
+    UserInterceptor interceptor;
+
+    @BeforeEach
+    void initTest() throws Exception {
+        mvc = MockMvcBuilders
+                .standaloneSetup(communicationController)
+                .addInterceptors(interceptor).build();
+        when(interceptor.preHandle(any(), any(), any())).thenReturn(true);
+    }
 
     @Test
     void getMessage() throws Exception {

--- a/src/test/java/com/team701/buddymatcher/controllers/communication/CommunicationControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/communication/CommunicationControllerIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -46,20 +47,20 @@ public class CommunicationControllerIntegrationTest {
 
     @Test
     void getMessage() throws Exception {
-        mvc.perform(get("/api/communication/messages/{id}", 1)
-                .queryParam("buddyId", String.valueOf(2)))
+        mvc.perform(get("/api/communication/messages/{id}",2)
+                        .sessionAttrs(Collections.singletonMap("UserId", 1)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1))
                 .andExpect(jsonPath("$[0].senderId").value(1))
                 .andExpect(jsonPath("$[0].receiverId").value(2))
-                .andExpect(jsonPath("$[0].timestamp").value("2022-03-16T01:29:36.000+00:00"))
+                .andExpect(jsonPath("$[0].timestamp").value("1647394176000"))
                 .andExpect(jsonPath("$[0].content").value("HARRO"))
                 .andExpect(jsonPath("$[0].read").value(true))
                 .andExpect(jsonPath("$[1].id").value(2))
                 .andExpect(jsonPath("$[1].senderId").value(2))
                 .andExpect(jsonPath("$[1].receiverId").value(1))
                 .andExpect(jsonPath("$[1].content").value("Yo HARRO"))
-                .andExpect(jsonPath("$[1].timestamp").value("2022-03-16T01:40:21.000+00:00"))
+                .andExpect(jsonPath("$[1].timestamp").value("1647394821000"))
                 .andExpect(jsonPath("$[1].read").value(false))
                 .andDo(print());
     }

--- a/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
@@ -3,7 +3,6 @@ package com.team701.buddymatcher.controllers.pairing;
 import com.team701.buddymatcher.config.JwtTokenUtil;
 import com.team701.buddymatcher.interceptor.UserInterceptor;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -13,6 +12,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -54,9 +55,11 @@ public class PairingControllerIntegrationTest {
     @Test
     void requestBuddyMatchFromCourseWithOneBuddy() throws Exception {
 
-        mvc.perform(get("/api/pairing/matchBuddy/{id}",4)
+        mvc.perform(get("/api/pairing/matchBuddy")
                         .content("{\"courseIds\":[3]}")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttrs(Collections.singletonMap("UserId", 4))
+                )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(6))
                 .andExpect(jsonPath("$[0].name").value("only sevenfifty"))
@@ -69,9 +72,10 @@ public class PairingControllerIntegrationTest {
     @Test
     void requestBuddyMatchFromCourseWithNoBuddy() throws Exception {
 
-        mvc.perform(get("/api/pairing/matchBuddy/{id}",4)
+        mvc.perform(get("/api/pairing/matchBuddy")
                         .content("{\"courseIds\":[2]}")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttrs(Collections.singletonMap("UserId", 4)))
                 .andExpect(status().isNoContent())
                 .andDo(print());
     }
@@ -79,18 +83,20 @@ public class PairingControllerIntegrationTest {
     @Test
     void requestBuddyMatchFromCourseWithCourseWithStudentNotPairing() throws Exception {
 
-        mvc.perform(get("/api/pairing/matchBuddy/{id}",4)
+        mvc.perform(get("/api/pairing/matchBuddy")
                         .content("{\"courseIds\":[2]}")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttrs(Collections.singletonMap("UserId", 4)))
                 .andExpect(status().isNoContent())
                 .andDo(print());
     }
 
     @Test
     void requestBuddyMatchFromCourseWithBuddy() throws Exception {
-        mvc.perform(get("/api/pairing/matchBuddy/{id}",4)
+        mvc.perform(get("/api/pairing/matchBuddy")
                         .content("{\"courseIds\":[5]}")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttrs(Collections.singletonMap("UserId", 4)))
                 .andExpect(status().isNoContent())
                 .andDo(print());
     }
@@ -98,9 +104,10 @@ public class PairingControllerIntegrationTest {
     @Test
     void requestBuddyMatchFromCourseWithMultipleStudents() throws Exception {
 
-        mvc.perform(get("/api/pairing/matchBuddy/{id}",4)
+        mvc.perform(get("/api/pairing/matchBuddy")
                         .content("{\"courseIds\":[1]}")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttrs(Collections.singletonMap("UserId", 4)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(2))
                 .andExpect(jsonPath("$[0].name").value("Green Dinosaur"))
@@ -115,9 +122,10 @@ public class PairingControllerIntegrationTest {
 
     @Test
     void requestBuddyMatchFromMultipleCoursesWithMultipleStudents() throws Exception {
-        mvc.perform(get("/api/pairing/matchBuddy/{id}",4)
+        mvc.perform(get("/api/pairing/matchBuddy")
                         .content("{\"courseIds\":[1,3]}")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttrs(Collections.singletonMap("UserId", 4)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(2))
                 .andExpect(jsonPath("$[0].name").value("Green Dinosaur"))
@@ -136,9 +144,10 @@ public class PairingControllerIntegrationTest {
 
     @Test
     void requestBuddyMatchFromCoursesWithSameStudentInBothCourses() throws Exception {
-        mvc.perform(get("/api/pairing/matchBuddy/{id}",4)
+        mvc.perform(get("/api/pairing/matchBuddy")
                         .content("{\"courseIds\":[1,4]}")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttrs(Collections.singletonMap("UserId", 4)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(2))
                 .andExpect(jsonPath("$[0].name").value("Green Dinosaur"))
@@ -148,82 +157,6 @@ public class PairingControllerIntegrationTest {
                 .andExpect(jsonPath("$[1].name").value("Hiruna Smith"))
                 .andExpect(jsonPath("$[1].email").value("hiruna.smith@gmail.com"))
                 .andExpect(jsonPath("$[1].pairingEnabled").value(true))
-                .andDo(print());
-    }
-
-    @Test
-    void addValidBuddy() throws Exception {
-
-        mvc.perform(post("/api/pairing/addBuddy/")
-                        .content("{\"userId\":3, \"buddyId\":4}")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andDo(print());
-    }
-
-    @Disabled
-    @Test
-    void addValidBuddyButInvalidUser() throws Exception {
-        //ToDo: need to refactor to return better status code
-        mvc.perform(post("/api/pairing/addBuddy/")
-                        .content("{\"userId\":7, \"buddyId\":3}")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andDo(print());
-    }
-
-
-    @Disabled
-    @Test
-    void addAlreadyAddedBuddy() throws Exception {
-        //ToDo: need to refactor to return better status code
-        mvc.perform(post("/api/pairing/addBuddy/")
-                        .content("{\"userId\":4, \"buddyId\":5}")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andDo(print());
-    }
-
-    @Disabled
-    @Test
-    void addInvalidBuddy() throws Exception {
-        //ToDo: need to refactor to return better status code
-        mvc.perform(post("/api/pairing/addBuddy/")
-                        .content("{\"userId\":4, \"buddyId\":7}")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andDo(print());
-    }
-
-    @Disabled
-    @Test
-    void addBuddyWhoDoesNotHavePairingEnabled() throws Exception {
-        //ToDo: need to refactor to return better status code
-        mvc.perform(post("/api/pairing/addBuddy/")
-                        .content("{\"userId\":4, \"buddyId\":1}")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andDo(print());
-
-    }
-
-    @Test
-    void removeBuddyValid() throws Exception {
-
-        mvc.perform(delete("/api/pairing/removeBuddy/")
-                        .content("{\"userId\":4, \"buddyId\":5}")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andDo(print());
-    }
-
-    @Test
-    void removeBuddyRecordThatDoesNotExist() throws Exception {
-        //ToDo: need to refactor to return better status code
-        mvc.perform(delete("/api/pairing/removeBuddy/")
-                        .content("{\"userId\":4, \"buddyId\":3}")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
                 .andDo(print());
     }
 }

--- a/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
@@ -1,14 +1,21 @@
 package com.team701.buddymatcher.controllers.pairing;
 
+import com.team701.buddymatcher.config.JwtTokenUtil;
+import com.team701.buddymatcher.interceptor.UserInterceptor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -26,8 +33,23 @@ public class PairingControllerIntegrationTest {
     @Autowired
     private MockMvc mvc;
 
+    private static final JwtTokenUtil jwtTokenUtil = new JwtTokenUtil();
+
+    @MockBean
+    UserInterceptor interceptor;
+
     @Autowired
     PairingController pairingController;
+
+
+    @BeforeEach
+    void initTest() throws Exception {
+        mvc = MockMvcBuilders
+                .standaloneSetup(pairingController)
+                .addInterceptors(interceptor).build();
+        when(interceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+    }
 
     @Test
     void requestBuddyMatchFromCourseWithOneBuddy() throws Exception {

--- a/src/test/java/com/team701/buddymatcher/controllers/timetable/TimetableControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/timetable/TimetableControllerIntegrationTest.java
@@ -1,12 +1,18 @@
 package com.team701.buddymatcher.controllers.timetable;
 
+import com.team701.buddymatcher.interceptor.UserInterceptor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -25,6 +31,17 @@ public class TimetableControllerIntegrationTest {
 
     @Autowired
     TimetableController timetableController;
+
+    @MockBean
+    UserInterceptor interceptor;
+
+    @BeforeEach
+    void initTest() throws Exception {
+        mvc = MockMvcBuilders
+                .standaloneSetup(timetableController)
+                .addInterceptors(interceptor).build();
+        when(interceptor.preHandle(any(), any(), any())).thenReturn(true);
+    }
 
     @Test
     void getUserCourses() throws Exception {

--- a/src/test/java/com/team701/buddymatcher/controllers/timetable/TimetableControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/timetable/TimetableControllerIntegrationTest.java
@@ -11,6 +11,8 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.Collections;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -45,27 +47,38 @@ public class TimetableControllerIntegrationTest {
 
     @Test
     void getUserCourses() throws Exception {
+        mvc.perform(get("/api/timetable/users/courses")
+                        .sessionAttrs(Collections.singletonMap("UserId", 1)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].courseId").value(1))
+                .andExpect(jsonPath("$[0].name").value("SOFTENG 701"))
+                .andExpect(jsonPath("$[0].semester").value("Semester 1 2022"))
+                .andExpect(jsonPath("$[0].studentCount").value(10))
+                .andExpect(jsonPath("$[0].updatedTime").value("1647394176000"))
+                .andDo(print());
+    }
 
+    @Test
+    void getCourses() throws Exception {
         mvc.perform(get("/api/timetable/users/courses/{id}", 1))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].courseId").value(1))
                 .andExpect(jsonPath("$[0].name").value("SOFTENG 701"))
                 .andExpect(jsonPath("$[0].semester").value("Semester 1 2022"))
                 .andExpect(jsonPath("$[0].studentCount").value(10))
-                .andExpect(jsonPath("$[0].updatedTime").value("2022-03-16T01:29:36.000+00:00"))
+                .andExpect(jsonPath("$[0].updatedTime").value("1647394176000"))
                 .andDo(print());
     }
 
     @Test
     void getCourse() throws Exception {
-
-        mvc.perform(get("/api/timetable/courses/{id}", 1))
+        mvc.perform(get("/api/timetable/course/{id}", 1))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.courseId").value(1))
                 .andExpect(jsonPath("$.name").value("SOFTENG 701"))
                 .andExpect(jsonPath("$.semester").value("Semester 1 2022"))
                 .andExpect(jsonPath("$.studentCount").value(10))
-                .andExpect(jsonPath("$.updatedTime").value("2022-03-16T01:29:36.000+00:00"))
+                .andExpect(jsonPath("$.updatedTime").value("1647394176000"))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/team701/buddymatcher/controllers/users/UserControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/users/UserControllerIntegrationTest.java
@@ -1,15 +1,20 @@
 package com.team701.buddymatcher.controllers.users;
 
+import com.team701.buddymatcher.interceptor.UserInterceptor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.Random;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -29,6 +34,17 @@ public class UserControllerIntegrationTest {
 
     @Autowired
     UserController userController;
+
+    @MockBean
+    UserInterceptor interceptor;
+
+    @BeforeEach
+    void initTest() throws Exception {
+        mvc = MockMvcBuilders
+                .standaloneSetup(userController)
+                .addInterceptors(interceptor).build();
+        when(interceptor.preHandle(any(), any(), any())).thenReturn(true);
+    }
 
     @Test
     void getExistingUser() throws Exception {

--- a/src/test/java/com/team701/buddymatcher/controllers/users/UserControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/users/UserControllerIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.Collections;
 import java.util.Random;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -47,6 +48,20 @@ public class UserControllerIntegrationTest {
     }
 
     @Test
+    void getSelf() throws Exception {
+
+        mvc.perform(get("/api/users")
+                        .sessionAttrs(Collections.singletonMap("UserId", 1)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Pink Elephant"))
+                .andExpect(jsonPath("$.email").value("pink.elephant@gmail.com"))
+                .andExpect(jsonPath("$.pairingEnabled").value(false))
+                .andDo(print());
+    }
+
+
+    @Test
     void getExistingUser() throws Exception {
 
         mvc.perform(get("/api/users/{id}", 1))
@@ -68,18 +83,20 @@ public class UserControllerIntegrationTest {
     }
 
     @Test
-    void updatePairingEnabledForNonExistingUser() throws Exception {
+    void updatePairingEnabledForSelf() throws Exception {
 
-        mvc.perform(put("/api/users/{id}", new Random().nextLong())
+        mvc.perform(put("/api/users")
+                        .sessionAttrs(Collections.singletonMap("UserId", 1))
                 .queryParam("pairingEnabled", String.valueOf(true)))
-                .andExpect(status().isNotFound())
+                .andExpect(status().isOk())
                 .andDo(print());
     }
 
     @Test
     void getUserBuddy() throws Exception {
 
-        mvc.perform(get("/api/users/buddy/{id}", 2))
+        mvc.perform(get("/api/users/buddy")
+                        .sessionAttrs(Collections.singletonMap("UserId", 2)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1))
                 .andExpect(jsonPath("$[0].name").value("Pink Elephant"))
@@ -99,13 +116,13 @@ public class UserControllerIntegrationTest {
     @Test
     void createAndDeleteUserBuddy() throws Exception {
 
-        mvc.perform(post("/api/users/buddy/{id}", 3)
-                        .queryParam("buddyId", String.valueOf(4)))
+        mvc.perform(post("/api/users/buddy/{id}", 4)
+                        .sessionAttrs(Collections.singletonMap("UserId", 3)))
                 .andExpect(status().isOk())
                 .andDo(print());
 
-        mvc.perform(delete("/api/users/buddy/{id}", 3)
-                        .queryParam("buddyId", String.valueOf(4)))
+        mvc.perform(delete("/api/users/buddy/{id}", 4)
+                        .sessionAttrs(Collections.singletonMap("UserId", 3)))
                 .andExpect(status().isOk())
                 .andDo(print());
     }

--- a/src/test/java/com/team701/buddymatcher/controllers/users/UserControllerUnitTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/users/UserControllerUnitTest.java
@@ -1,18 +1,17 @@
 package com.team701.buddymatcher.controllers.users;
 
-import com.team701.buddymatcher.domain.users.Buddies;
 import com.team701.buddymatcher.domain.users.User;
-import com.team701.buddymatcher.dtos.users.BuddiesDTO;
 import com.team701.buddymatcher.dtos.users.UserDTO;
+import com.team701.buddymatcher.interceptor.UserInterceptor;
 import com.team701.buddymatcher.services.users.UserService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
@@ -20,11 +19,15 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.NoSuchElementException;
 import java.util.Random;
 
+import static org.mockito.Mockito.when;
+
 @ExtendWith(MockitoExtension.class)
 public class UserControllerUnitTest {
 
     @Mock
     private UserService userService;
+
+
 
     @Mock
     private ModelMapper modelMapper;
@@ -32,15 +35,18 @@ public class UserControllerUnitTest {
     @InjectMocks
     private UserController userController;
 
+    @MockBean
+    UserInterceptor interceptor;
+
     @Test
     void retrievingExistingUserReturnsCorrectResponseEntity() {
         Long id = new Random().nextLong();
 
         User mockedUser = createMockUser(id);
-        Mockito.when(userService.retrieveById(id)).thenReturn(mockedUser);
+        when(userService.retrieveById(id)).thenReturn(mockedUser);
 
         UserDTO mockedUserDTO = createMockedUserDTO(mockedUser);
-        Mockito.when(modelMapper.map(mockedUser, UserDTO.class)).thenReturn(mockedUserDTO);
+        when(modelMapper.map(mockedUser, UserDTO.class)).thenReturn(mockedUserDTO);
 
         ResponseEntity<UserDTO> response = userController.retrieveUserById(id);
 
@@ -53,7 +59,7 @@ public class UserControllerUnitTest {
     void retrievingNonExistentUserThrowsException() {
         Long id = new Random().nextLong();
 
-        Mockito.when(userService.retrieveById(id)).thenThrow(new NoSuchElementException());
+        when(userService.retrieveById(id)).thenThrow(new NoSuchElementException());
 
         Assertions.assertThrows(ResponseStatusException.class, () -> userController.retrieveUserById(id));
 

--- a/src/test/java/com/team701/buddymatcher/controllers/users/ValidateControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/users/ValidateControllerIntegrationTest.java
@@ -2,14 +2,20 @@ package com.team701.buddymatcher.controllers.users;
 
 import com.team701.buddymatcher.config.JwtTokenUtil;
 import com.team701.buddymatcher.domain.users.User;
+import com.team701.buddymatcher.interceptor.UserInterceptor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.Random;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,14 +26,28 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class ValidateControllerIntegrationTest {
 
-    @Autowired
-    private MockMvc mvc;
+
+    @MockBean
+    UserInterceptor interceptor;
 
     @Autowired
     private ValidateController validateController;
 
+    @Autowired
+    private MockMvc mvc;
+
     private static final JwtTokenUtil jwtTokenUtil = new JwtTokenUtil();
 
+
+
+    @BeforeEach
+    void initTest() throws Exception {
+        mvc = MockMvcBuilders
+                .standaloneSetup(validateController)
+                .addInterceptors(interceptor).build();
+        when(interceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+    }
     @Test
     void validateValidToken() throws Exception {
         String token = createValidToken();


### PR DESCRIPTION
## Description

This PR finishes off existing work from @JafarMaash in https://github.com/JafarMaash/backend/tree/57-auth-interceptor

This PR fixes #57, fixes #82, fixes #50 
- Add auth method to get called before every endpoint
- Refactors All endpoints to use authorisation
  - Refactor user endpoints to use authorisation
  - Refactor pairing endpoints to use authorisation
- Update unit tests to reflect refactor
- Update swagger to support JWT authorization bearer tokens

Added two fake endpoints
- api/user/fake/login
- api/user/fake/register
These endpoints are used for the frontend to test code without Google Auth

## How has this been tested?
- All tests pass integration testing
- Manual testing has been done to test swagger documentation

## Screenshots

![image](https://user-images.githubusercontent.com/23299540/159031004-5b6b1f19-fb5f-43a9-ae29-33ab6be3d0df.png)
![image](https://user-images.githubusercontent.com/23299540/159031031-8acd5243-e4ba-4a7e-ac2e-58ae8923f983.png)


Fake testing endpoints (need env variable to disable on production)
![image](https://user-images.githubusercontent.com/23299540/159030929-23a45046-ecf0-4a32-a0c0-702058122bd3.png)


## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
