### PR TITLE
Add buddy count to User DTO

### DIFF
--- a/src/main/java/com/team701/buddymatcher/controllers/users/UserController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/users/UserController.java
@@ -65,6 +65,9 @@ public class UserController {
             User user = userService.retrieveById(userId);
             UserDTO userDTO = modelMapper.map(user, UserDTO.class);
 
+            Long buddyCount = userService.countBuddies(user);
+            userDTO.setBuddyCount(buddyCount);
+
             return new ResponseEntity<>(userDTO, HttpStatus.OK);
         } catch (NoSuchElementException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");

--- a/src/main/java/com/team701/buddymatcher/dtos/users/UserDTO.java
+++ b/src/main/java/com/team701/buddymatcher/dtos/users/UserDTO.java
@@ -6,6 +6,7 @@ public class UserDTO {
     private String name;
     private String email;
     private Boolean pairingEnabled;
+    private Long buddyCount;
 
     public Long getId() {
         return id;
@@ -40,6 +41,15 @@ public class UserDTO {
 
     public UserDTO setPairingEnabled(Boolean pairingEnabled) {
         this.pairingEnabled = pairingEnabled;
+        return this;
+    }
+
+    public Long getBuddyCount() {
+        return buddyCount;
+    }
+
+    public UserDTO setBuddyCount(Long buddyCount) {
+        this.buddyCount = buddyCount;
         return this;
     }
 }

--- a/src/main/java/com/team701/buddymatcher/repositories/BuddiesRepository.java
+++ b/src/main/java/com/team701/buddymatcher/repositories/BuddiesRepository.java
@@ -1,0 +1,10 @@
+package com.team701.buddymatcher.repositories;
+
+import com.team701.buddymatcher.domain.users.Buddies;
+import com.team701.buddymatcher.domain.users.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BuddiesRepository extends JpaRepository<Buddies, Long> {
+
+    Long countByUser0OrUser1(User user0, User user1);
+}

--- a/src/main/java/com/team701/buddymatcher/repositories/users/UserRepository.java
+++ b/src/main/java/com/team701/buddymatcher/repositories/users/UserRepository.java
@@ -27,9 +27,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query(value = "SELECT * FROM User u JOIN Buddies b ON b.user_0_id=u.id WHERE b.user_1_id=:userId UNION SELECT * FROM User u JOIN Buddies b ON b.user_1_id=u.id WHERE b.user_0_id=:userId", nativeQuery=true)
     List<User> findBuddies(@Param("userId") Long userId);
 
-    @Query(value = "SELECT COUNT(*) FROM (SELECT * FROM User u JOIN Buddies b ON b.user_0_id=u.id WHERE b.user_1_id=:userId UNION SELECT * FROM User u JOIN Buddies b ON b.user_1_id=u.id WHERE b.user_0_id=:userId)", nativeQuery=true)
-    Integer countBuddies(@Param("userId") Long userId);
-
     /**
      * Create buddy creates a buddy pair
      * To assure integrity of the data user0 != user1 and user0 < user1

--- a/src/main/java/com/team701/buddymatcher/services/users/UserService.java
+++ b/src/main/java/com/team701/buddymatcher/services/users/UserService.java
@@ -12,7 +12,7 @@ public interface UserService {
     void addUser(String name, String email);
 
     List<User> retrieveBuddiesByUserId(Long userId);
-    Integer retrieveBuddyCountByUserId(Long userId);
+    Long countBuddies(User user);
 
     void addBuddy(Long currentUserId, Long buddyUserId) throws
             NoSuchElementException;

--- a/src/main/java/com/team701/buddymatcher/services/users/impl/UserServiceImpl.java
+++ b/src/main/java/com/team701/buddymatcher/services/users/impl/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.team701.buddymatcher.services.users.impl;
 
 import com.team701.buddymatcher.domain.users.User;
+import com.team701.buddymatcher.repositories.BuddiesRepository;
 import com.team701.buddymatcher.repositories.users.UserRepository;
 import com.team701.buddymatcher.services.users.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,10 +14,12 @@ import java.util.NoSuchElementException;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private BuddiesRepository buddiesRepository;
 
     @Autowired
-    public UserServiceImpl(UserRepository userRepository) {
+    public UserServiceImpl(UserRepository userRepository, BuddiesRepository buddiesRepository) {
         this.userRepository = userRepository;
+        this.buddiesRepository = buddiesRepository;
     }
 
     @Override
@@ -49,8 +52,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Integer retrieveBuddyCountByUserId(Long userId) {
-        return userRepository.countBuddies(userId);
+    public Long countBuddies(User user) {
+        return buddiesRepository.countByUser0OrUser1(user, user);
     }
 
     @Override

--- a/src/test/java/com/team701/buddymatcher/controllers/users/UserControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/users/UserControllerIntegrationTest.java
@@ -57,7 +57,7 @@ public class UserControllerIntegrationTest {
                 .andExpect(jsonPath("$.name").value("Pink Elephant"))
                 .andExpect(jsonPath("$.email").value("pink.elephant@gmail.com"))
                 .andExpect(jsonPath("$.pairingEnabled").value(false))
-                .andDo(print());
+                .andExpect(jsonPath("$.buddyCount").value(3));
     }
 
 
@@ -70,7 +70,7 @@ public class UserControllerIntegrationTest {
                 .andExpect(jsonPath("$.name").value("Pink Elephant"))
                 .andExpect(jsonPath("$.email").value("pink.elephant@gmail.com"))
                 .andExpect(jsonPath("$.pairingEnabled").value(false))
-                .andDo(print());
+                .andExpect(jsonPath("$.buddyCount").value(3));
     }
 
     @Test
@@ -78,8 +78,7 @@ public class UserControllerIntegrationTest {
 
         mvc.perform(get("/api/users/{id}", new Random().nextLong())
                 .queryParam("pairingEnabled", String.valueOf(true)))
-                .andExpect(status().isNotFound())
-                .andDo(print());
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -88,8 +87,7 @@ public class UserControllerIntegrationTest {
         mvc.perform(put("/api/users")
                         .sessionAttrs(Collections.singletonMap("UserId", 1))
                 .queryParam("pairingEnabled", String.valueOf(true)))
-                .andExpect(status().isOk())
-                .andDo(print());
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -109,8 +107,7 @@ public class UserControllerIntegrationTest {
                 .andExpect(jsonPath("$[2].id").value(4))
                 .andExpect(jsonPath("$[2].name").value("Flynn Smith"))
                 .andExpect(jsonPath("$[2].email").value("flynn.smith@gmail.com"))
-                .andExpect(jsonPath("$[2].pairingEnabled").value(false))
-                .andDo(print());
+                .andExpect(jsonPath("$[2].pairingEnabled").value(false));
     }
 
     @Test
@@ -123,8 +120,7 @@ public class UserControllerIntegrationTest {
 
         mvc.perform(delete("/api/users/buddy/{id}", 4)
                         .sessionAttrs(Collections.singletonMap("UserId", 3)))
-                .andExpect(status().isOk())
-                .andDo(print());
+                .andExpect(status().isOk());
     }
 
 }

--- a/src/test/java/com/team701/buddymatcher/controllers/users/UserControllerUnitTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/users/UserControllerUnitTest.java
@@ -76,6 +76,7 @@ public class UserControllerUnitTest {
         return new UserDTO()
                 .setId(mockedUser.getId())
                 .setName(mockedUser.getName())
-                .setEmail(mockedUser.getEmail());
+                .setEmail(mockedUser.getEmail())
+                .setBuddyCount(2L);
     }
 }


### PR DESCRIPTION
## Description
Adding a buddyCount field to `UserDTO` so that the frontend can get the number of buddies a user has through existing endpoints (GET /api/users/{id} and GET /api/users)

Also fixed the query to retrieve a user's buddy count by creating a `BuddiesRepository` and using 
JPA Query Creation from method names. Previously the error for this query was:
![image](https://user-images.githubusercontent.com/68877945/159108585-8b0def36-f696-4039-938d-423af7aca672.png)

Closes #83 

## How has this been tested?
Added buddyCount field to both `UserControllerUnitTest` and `UserControllerIntegrationTest`, all tests pass

## Screenshots

## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
