### PR TITLE
Move google API client id to environment variables

### DIFF
--- a/src/main/java/com/team701/buddymatcher/controllers/users/UserController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/users/UserController.java
@@ -36,6 +36,9 @@ import java.util.stream.Collectors;
 @SecurityRequirement(name = "JWT")
 public class UserController {
 
+    // Set Google console client ID in environment variables: see frontend wiki "Authentication flow" for how
+    public static final String CLIENT_ID = System.getenv("CLIENT_ID");
+
     private final UserService userService;
 
     private ModelMapper modelMapper;
@@ -88,7 +91,6 @@ public class UserController {
     @Operation(summary = "Get method for a user logging in using Google")
     @GetMapping(path = "/login", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> loginWithGoogle(HttpServletRequest request) throws GeneralSecurityException, IOException {
-        String CLIENT_ID = "158309441002-q8q49tjicngt1tp6p9t7ecvdrn9ar78j.apps.googleusercontent.com";
         GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier
                 .Builder(new NetHttpTransport(), new GsonFactory())
                 // Specify the CLIENT_ID of the app that accesses the backend:


### PR DESCRIPTION
## Description
Removed sensitive client ID from the code, abstracting it to env variable.

Google developer TOS prohibits embedding client ID in open-source software. Instructions for how to set client id as an env variable can be found in [front end wiki](https://github.com/SE701-T1/frontend/wiki/Environment-Setup)

## How has this been tested?
I ran it and it worked 

## Screenshots
See above link for screenshots. I am a bit tired 

## Checklist
*(Leave blank if not applicable)*

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
