### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,15 +3,19 @@
 
 name: Java CI with Maven
 
+# Events that trigger the workflow
 on:
+  # This workflow is run when pull requests to either the main or a2-main branch are opened, reopened, and synchronized
   pull_request:
     branches: [ main, a2-main ]
 
+# The workflow jobs: builds and tests the backend
 jobs:
   build:
-
+    # Workflow job is run on the latest Ubuntu runner
     runs-on: ubuntu-latest
 
+    # Sequence of tasks for completing the workflow job
     steps:
     - name: Change Timezone to NZT
       uses: szenius/set-timezone@v1.0
@@ -21,11 +25,15 @@ jobs:
         timezoneWindows: "New Zealand Standard Time"
 
     - uses: actions/checkout@v2
+
+    # Runs the workflow job using JDK 17
     - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+
+      # Builds and tests the project
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,7 +5,7 @@ name: Java CI with Maven
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, a2-main ]
 
 jobs:
   build:


### PR DESCRIPTION
## Description

Fixes Issue #144 

The CI workflow for GitHub actions has not been running in pull requests when merging to the a2-main branch. The a2-main branch is now the default branch and all pull requests are expected to be merged there for at least the remainder of the second assignment.

The CI workflow required being updated so that the GitHub actions CI workflows are executed for pull request events when the a2-main branch is the base branch.

## How has this been tested?

It has been tested locally. The fix is for a GitHub action workflow so there is no new testing.

## Checklist
*(Leave blank if not applicable)*

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
