### PR TITLE
Refactor pull_request_template.md - comment out instructions, unlink example issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
 ## Description
-*Please include a summary of the change and which issue number is fixed (e.g. Fixes #1). Please also include relevant motivation and context.*
+<!-- *Please include a summary of the change and which issue number is fixed (e.g. Fixes #1). Please also include relevant motivation and context.* -->
 
 ## How has this been tested?
-*Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.*
+<!-- *Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.* -->
 
 ## Screenshots
-*Provide screenshots of what has been implemented. Leave blank if not applicable*
+<!-- *Provide screenshots of what has been implemented. Leave blank if not applicable* -->
 
 ## Checklist
-*(Leave blank if not applicable)*
+<!-- *(Leave blank if not applicable)* -->
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code


### PR DESCRIPTION
## Description
<!-- *Please include a summary of the change and which issue number is fixed (e.g. Fixes #1). Please also include relevant motivation and context.* -->

It has been noticed in pull requests that ```Issue #1``` is being automatically associated and cannot be removed after the pull request is created. This is because it is being used as an example in the Description instructions in the ```pull_request_template.md```. The instructions should not be removed so a refactor is the proposed solution. The solution involves turning each instruction into a comment they can be read when authoring pull requests while not being included when creating the pull request. 

## How has this been tested?
<!-- *Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.* -->

It has been tested locally and proof read. It is documentation so there is no new testing.

## Checklist
<!-- *(Leave blank if not applicable)* -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
