### PR TITLE
ISSUE 124: Improved Buddy Searching To Prioritise Shared Courses

### DIFF
--- a/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
+++ b/src/main/java/com/team701/buddymatcher/controllers/pairing/PairingController.java
@@ -71,7 +71,6 @@ public class PairingController {
              */
             List<UserDTO> matches = results.stream()
                     .filter(User::getPairingEnabled)
-                    .filter(user -> !user.getId().equals(userId))
                     .filter(user -> !currentBuddies.contains(user.getId()))
                     .map(user -> {
                         //Map the user object to a DTO and then set the buddy count

--- a/src/main/java/com/team701/buddymatcher/repositories/users/UserRepository.java
+++ b/src/main/java/com/team701/buddymatcher/repositories/users/UserRepository.java
@@ -59,4 +59,15 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query(value = "SELECT * FROM User u JOIN Blocked_Buddies b ON b.user_blocked_id=u.id " +
             "WHERE b.user_blocker_id=:userBlockerId", nativeQuery=true)
     List<User> getBlockedBuddies(@Param("userBlockerId") Long userBlockerId);
+
+    /**
+     * Find all potential buddies for a specific user based on their courses. Sort by how many common courses users
+     * have in descending order.
+     * @param userId the user ID of the user looking for potential buddies
+     * @param courseIds the course IDs of the courses the current user is taking
+     * @return a sorted list of buddies who share courses
+     */
+    @Query(value = "SELECT u, COUNT(u) as matches from User u JOIN u.courses c WHERE c.courseId IN ?2 " +
+            "AND u.id <> ?1 GROUP BY u.id ORDER BY matches DESC")
+    List<User> getSortedPotentialBuddies(@Param("userId") Long userId, @Param("courseIds")List<Long> courseIds);
 }

--- a/src/main/java/com/team701/buddymatcher/services/pairing/impl/PairingServiceImpl.java
+++ b/src/main/java/com/team701/buddymatcher/services/pairing/impl/PairingServiceImpl.java
@@ -38,9 +38,8 @@ public class PairingServiceImpl implements PairingService {
         this.userService.deleteBuddy(userId, buddyId);
     }
 
-    @Override
     public List<User> matchBuddy(Long userId, List<Long> courseIds) {
-        return this.timetableService.getUsersFromCourseIds(courseIds);
+        return this.userService.getSortedPotentialBuddies(userId, courseIds);
     }
 
     @Override

--- a/src/main/java/com/team701/buddymatcher/services/users/UserService.java
+++ b/src/main/java/com/team701/buddymatcher/services/users/UserService.java
@@ -18,6 +18,15 @@ public interface UserService {
 
     List<User> retrieveBuddiesByUserId(Long userId);
 
+    /**
+     * Find all potential buddies for a specific user based on their courses.
+     * Sort by how many common courses users have.
+     * @param userId the user ID of the user looking for potential buddies
+     * @param courseIds the course IDs of the courses the current user is taking
+     * @return a sorted list of buddies who share courses
+     */
+    List<User> getSortedPotentialBuddies(Long userId, List<Long> courseIds);
+
     Long countBuddies(User user);
 
     void addBuddy(Long currentUserId, Long buddyUserId);

--- a/src/main/java/com/team701/buddymatcher/services/users/impl/UserServiceImpl.java
+++ b/src/main/java/com/team701/buddymatcher/services/users/impl/UserServiceImpl.java
@@ -33,6 +33,8 @@ public class UserServiceImpl implements UserService {
         this.reportedBuddiesRepository = reportedBuddiesRepository;
     }
 
+
+
     @Override
     public User retrieveById(Long id) throws NoSuchElementException {
         return this.userRepository.findById(id).orElseThrow();
@@ -54,6 +56,18 @@ public class UserServiceImpl implements UserService {
     @Override
     public void addUser(String name, String email) throws DataIntegrityViolationException {
         this.userRepository.createUser(name, email);
+    }
+
+    /**
+     * Find all potential buddies for a specific user based on their courses.
+     * Sort by how many common courses users have.
+     * @param userId the user ID of the user looking for potential buddies
+     * @param courseIds the course IDs of the courses the current user is taking
+     * @return a sorted list of buddies who share courses
+     */
+    @Override
+    public List<User> getSortedPotentialBuddies(Long userId, List<Long> courseIds){
+        return this.userRepository.getSortedPotentialBuddies(userId, courseIds);
     }
 
     @Override

--- a/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
+++ b/src/test/java/com/team701/buddymatcher/controllers/pairing/PairingControllerIntegrationTest.java
@@ -136,6 +136,10 @@ public class PairingControllerIntegrationTest {
                 .andExpect(jsonPath("$[2].pairingEnabled").value(true));
     }
 
+    /**
+     * Will also check that buddies are correctly prioritised, with more shared courses appearing first
+     * @throws Exception
+     */
     @Test
     void requestBuddyMatchFromCoursesWithSameStudentInBothCourses() throws Exception {
         mvc.perform(post("/api/pairing/matchBuddy")
@@ -143,13 +147,13 @@ public class PairingControllerIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .sessionAttrs(Collections.singletonMap("UserId", 4)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").value(2))
-                .andExpect(jsonPath("$[0].name").value("Green Dinosaur"))
-                .andExpect(jsonPath("$[0].email").value("green.dinosaur@gmail.com"))
+                .andExpect(jsonPath("$[0].id").value(3))
+                .andExpect(jsonPath("$[0].name").value("Hiruna Smith"))
+                .andExpect(jsonPath("$[0].email").value("hiruna.smith@gmail.com"))
                 .andExpect(jsonPath("$[0].pairingEnabled").value(true))
-                .andExpect(jsonPath("$[1].id").value(3))
-                .andExpect(jsonPath("$[1].name").value("Hiruna Smith"))
-                .andExpect(jsonPath("$[1].email").value("hiruna.smith@gmail.com"))
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].name").value("Green Dinosaur"))
+                .andExpect(jsonPath("$[1].email").value("green.dinosaur@gmail.com"))
                 .andExpect(jsonPath("$[1].pairingEnabled").value(true));
     }
 }


### PR DESCRIPTION

## Description
Refers to ISSUE #124 , as an update to how potential buddies are presented to the user. Before, buddies were simply sorted by their storage in the database, they are now retrieved and sorted by how many courses they share with the user that made the request.

## How has this been tested?
Slight functionality change, so most test cases are unchanged. When multiple buddies share multiple courses with the requested user id, higher number of shared courses will be prioritised. The test "requestBuddyMatchFromCoursesWithSameStudentInBothCourses" has been changed to reflect this.

- [ ✓] My code follows the style guidelines of this project
- [ ✓] I have performed a self-review of my own code
- [ ✓] I have commented my code, particularly in hard-to-understand areas
- [ ✓] I have made corresponding changes to the documentation
- [ ✓] My changes generate no new warnings
- [ ✓] I have added tests that prove my fix is effective or that my feature works
- [ ✓] New and existing unit tests pass locally with my changes
- [ ✓] Any dependent changes have been merged and published in downstream modules
- [ ✓] I have checked my code and corrected any misspellings
